### PR TITLE
Reduced amount of useless error logs

### DIFF
--- a/src/Spryker/Zed/AppKernel/Persistence/AppKernelRepository.php
+++ b/src/Spryker/Zed/AppKernel/Persistence/AppKernelRepository.php
@@ -33,10 +33,6 @@ class AppKernelRepository extends AbstractRepository implements AppKernelReposit
         if ($appConfigEntity === null) {
             $errorMessage = 'Could not find an App configuration for the given Tenant';
 
-            $this->getLogger()->error($errorMessage, [
-                'tenantIdentifier' => $appConfigCriteriaTransfer->getTenantIdentifierOrFail(),
-            ]);
-
             throw new AppConfigNotFoundException($errorMessage);
         }
 


### PR DESCRIPTION
## PR Description
Because the method is used in the config validator (e.g. in Stripe), for the first configuration (the DB record does not exist yet).
The logger generates 5 error records 
![image](https://github.com/user-attachments/assets/a6e95903-e2d4-4bce-9feb-dbe06644648f)
(which are useless in the configuration case)

Tests with Stripe app: https://github.com/spryker-projects/app-stripe/pull/224

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
